### PR TITLE
[WIP] Upped LocalDb library to 0.2.0 with bump to 0.2.0

### DIFF
--- a/build/Build.Version.targets
+++ b/build/Build.Version.targets
@@ -2,7 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <MajorVersion>0</MajorVersion>
-    <MinorVersion>1</MinorVersion>
+    <MinorVersion>3</MinorVersion>
     <PatchVersion>0</PatchVersion>
   </PropertyGroup>
 

--- a/src/LocalDb/ILocalDbConfiguration.cs
+++ b/src/LocalDb/ILocalDbConfiguration.cs
@@ -1,9 +1,12 @@
-﻿namespace RimDev.Sandbox.LocalDb
+﻿using System;
+
+namespace RimDev.Sandbox.LocalDb
 {
     public interface ILocalDbConfiguration
     {
         ILocalDbConfiguration WithVersion(string version);
         ILocalDbConfiguration WithDatabaseName(string databaseName);
         ILocalDbConfiguration WithDatabasePrefix(string databasePrefix);
+        ILocalDbConfiguration WithDatabaseSuffix(Func<string> databaseSuffixGenerator);
     }
 }

--- a/src/LocalDb/LocalDb.csproj
+++ b/src/LocalDb/LocalDb.csproj
@@ -33,7 +33,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="RimDev.Automation.Sql">
-      <HintPath>..\..\packages\RimDev.Automation.Sql.0.1.1\lib\net45\RimDev.Automation.Sql.dll</HintPath>
+      <HintPath>..\..\packages\RimDev.Automation.Sql.0.2.0\lib\net45\RimDev.Automation.Sql.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/LocalDb/LocalDbGrain.cs
+++ b/src/LocalDb/LocalDbGrain.cs
@@ -13,15 +13,17 @@ namespace RimDev.Sandbox.LocalDb
             
             Name = name;
             DatabasePrefix = Name;
-            Version = RimDev.Automation.Sql.LocalDb.Versions.InstalledVersions.FirstOrDefault();
+            Version = Automation.Sql.LocalDb.Versions.InstalledVersions.FirstOrDefault();
+            DatabaseSuffixGenerator = () => string.Format("{0}_{1}", Guid.NewGuid().ToString("N"), DateTime.Now.Ticks);
         }
 
         public string Name { get; protected set; }
         public string Version { get; protected set; }
         public string DatabaseName { get; protected set; }
         public string DatabasePrefix { get; protected set; }
+        public Func<string> DatabaseSuffixGenerator { get; protected set; }
 
-        public RimDev.Automation.Sql.LocalDb Instance { get; protected set; }
+        public Automation.Sql.LocalDb Instance { get; protected set; }
 
         public void Dispose()
         {
@@ -32,7 +34,7 @@ namespace RimDev.Sandbox.LocalDb
         public void Setup(Sandbox sandbox)
         {
             var location = sandbox.CreateGrainDirectory(this);
-            Instance = new RimDev.Automation.Sql.LocalDb(DatabaseName, Version, location, DatabasePrefix);
+            Instance = new RimDev.Automation.Sql.LocalDb(DatabaseName, Version, location, DatabasePrefix, DatabaseSuffixGenerator);
         }
 
         public ILocalDbConfiguration WithVersion(string version)
@@ -56,6 +58,14 @@ namespace RimDev.Sandbox.LocalDb
             if (databasePrefix == null) throw new ArgumentNullException("databasePrefix");
             DatabasePrefix = databasePrefix;
             
+            return this;
+        }
+
+        public ILocalDbConfiguration WithDatabaseSuffix(Func<string> databaseSuffixGenerator)
+        {
+            if (databaseSuffixGenerator == null) throw new ArgumentNullException("databaseSuffixGenerator");
+            DatabaseSuffixGenerator = databaseSuffixGenerator;
+
             return this;
         }
     }

--- a/src/LocalDb/packages.config
+++ b/src/LocalDb/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="RimDev.Automation.Sql" version="0.1.1" targetFramework="net45" />
+  <package id="RimDev.Automation.Sql" version="0.2.0" targetFramework="net45" />
 </packages>

--- a/tests/Intersection.Tests/Intersection.Tests.csproj
+++ b/tests/Intersection.Tests/Intersection.Tests.csproj
@@ -35,7 +35,7 @@
       <HintPath>..\..\packages\RimDev.Automation.Transform.0.1.0\lib\net45\Microsoft.Web.XmlTransform.dll</HintPath>
     </Reference>
     <Reference Include="RimDev.Automation.Sql">
-      <HintPath>..\..\packages\RimDev.Automation.Sql.0.1.1\lib\net45\RimDev.Automation.Sql.dll</HintPath>
+      <HintPath>..\..\packages\RimDev.Automation.Sql.0.2.0\lib\net45\RimDev.Automation.Sql.dll</HintPath>
     </Reference>
     <Reference Include="RimDev.Automation.Transform">
       <HintPath>..\..\packages\RimDev.Automation.Transform.0.1.0\lib\net45\RimDev.Automation.Transform.dll</HintPath>

--- a/tests/Intersection.Tests/packages.config
+++ b/tests/Intersection.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="RimDev.Automation.Sql" version="0.1.1" targetFramework="net451" />
+  <package id="RimDev.Automation.Sql" version="0.2.0" targetFramework="net45" />
   <package id="RimDev.Automation.Transform" version="0.1.0" targetFramework="net451" />
   <package id="RimDev.Automation.WebHosting" version="0.1.0" targetFramework="net451" />
   <package id="xunit" version="1.9.2" targetFramework="net451" />

--- a/tests/LocalDb.Tests/LocalDb.Tests.csproj
+++ b/tests/LocalDb.Tests/LocalDb.Tests.csproj
@@ -32,7 +32,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="RimDev.Automation.Sql">
-      <HintPath>..\..\packages\RimDev.Automation.Sql.0.1.1\lib\net45\RimDev.Automation.Sql.dll</HintPath>
+      <HintPath>..\..\packages\RimDev.Automation.Sql.0.2.0\lib\net45\RimDev.Automation.Sql.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/tests/LocalDb.Tests/packages.config
+++ b/tests/LocalDb.Tests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="RimDev.Automation.Sql" version="0.1.1" targetFramework="net451" />
+  <package id="RimDev.Automation.Sql" version="0.2.0" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net451" />
 </packages>


### PR DESCRIPTION
Upgraded LocalDb library to 0.2.0 to support datbase suffix feature
that will allow sandbox users to generate the suffix appeneded
to the database name.

By default, the suffix is now {Guid}_{DateTime.Now.Ticks}. This will
garauntee uniqueness of database names, while still allowing users
to narrow down a database to a particular time (if necessary).