### PR TITLE
Update RimDev.Automation.Sql dependency version

### DIFF
--- a/src/LocalDb/LocalDb.nuspec
+++ b/src/LocalDb/LocalDb.nuspec
@@ -11,7 +11,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <tags>rimdev sandbox automation localdb</tags>
     <dependencies>
-      <dependency id="RimDev.Automation.Sql" version="[0.1,1.0)" />
+      <dependency id="RimDev.Automation.Sql" version="[0.3.0,1.0)" />
       <dependency id="RimDev.Sandbox" version="$version$" />
     </dependencies>
   </metadata>


### PR DESCRIPTION
Update the dependency version of [**RimDev.Automation.Sql**](https://github.com/ritterim/automation-sql) as versions `0.1.0` and `0.1.1` of this package do not compile. Versions `0.2.0` and `0.3.0` compile, though.